### PR TITLE
Fix cronjob not running in container

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,6 @@ The application uses two ports:
 
 Sample env file is provided in the repository. Change it for your bot and server location.
 
-Also, I have defined 7 links for playlists for 7 days week. Cronjob inside the container will change the playlist at 
-00:05, so the music for each day will be different. If you want, just copy and paste your playlist 7 times -- and
+Also, I have defined 7 links for playlists for 7 days week. Cronjob inside the container will change the playlist at
+00:30, so the music for each day will be different. If you want, just copy and paste your playlist 7 times -- and
 it will play the same music.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,8 @@
 
 source ./env
 
+service cron start
+
 uvicorn src.api:app --host 0.0.0.0 --port "$API_PORT" &
 (sleep 10; bash /app/src/start_new_party.sh) &
 python3 main.py


### PR DESCRIPTION
## Summary
- start the cron daemon in the Docker entrypoint
- document the actual cron schedule

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `shellcheck entrypoint.sh src/start_new_party.sh`


------
https://chatgpt.com/codex/tasks/task_e_683f3f89a5ac832abad6dfdc6aac9bf2